### PR TITLE
fix log

### DIFF
--- a/src/asset/sqs.go
+++ b/src/asset/sqs.go
@@ -49,6 +49,7 @@ func newSQSConsumer() *worker.Worker {
 			Region: &conf.AWSRegion,
 		})
 	}
+	appLogger.Infof("Created SQS client, sqsConfig=%+v", conf)
 	return &worker.Worker{
 		Config: &worker.Config{
 			QueueName:          conf.AssetQueueName,


### PR DESCRIPTION
エラー解析のため、ログ出力を追加します。
また、コメントに追記しましたが、GoogleのAPIのリトライ処理に関するドキュメントで以下の記載がありましたので、リトライ時は３０秒以上の遅延を入れるようにします（パラメータ変更）

https://cloud.google.com/apis/design/errors#retrying_errors
> For 429 RESOURCE_EXHAUSTED errors, the client may retry at the higher level with minimum 30s delay. Such retries are only useful for long running background jobs.
