### PR TITLE
reduce search asset types

### DIFF
--- a/src/asset/asset.go
+++ b/src/asset/asset.go
@@ -54,9 +54,23 @@ func newAssetClient() assetServiceClient {
 	}
 }
 
+const (
+	// Supported asset types: https://cloud.google.com/asset-inventory/docs/supported-asset-types
+	assetTypeServiceAccount    string = "iam.googleapis.com/ServiceAccount"    // IAM
+	assetTypeServiceAccountKey string = "iam.googleapis.com/ServiceAccountKey" // IAM
+	assetTypeRole              string = "iam.googleapis.com/Role"              // IAM
+	assetTypeBucket            string = "storage.googleapis.com/Bucket"        // Storage
+)
+
 func (a *assetClient) listAsset(ctx context.Context, gcpProjectID string) *asset.ResourceSearchResultIterator {
 	return a.asset.SearchAllResources(ctx, &assetpb.SearchAllResourcesRequest{
 		Scope: "projects/" + gcpProjectID,
+		AssetTypes: []string{
+			assetTypeServiceAccount,
+			assetTypeServiceAccountKey,
+			assetTypeRole,
+			assetTypeBucket,
+		},
 	})
 }
 

--- a/src/asset/handler.go
+++ b/src/asset/handler.go
@@ -264,8 +264,6 @@ func (s *sqsHandler) analyzeAlert(ctx context.Context, projectID uint32) error {
 }
 
 const (
-	// Supported asset types: https://cloud.google.com/asset-inventory/docs/supported-asset-types
-	assetTypeServiceAccount        string = "iam.googleapis.com/ServiceAccount"
 	userServiceAccountEmailPattern string = ".iam.gserviceaccount.com"
 
 	// Basic roles: https://cloud.google.com/iam/docs/understanding-roles


### PR DESCRIPTION
https://github.com/CyberAgent/risken-community/issues/35 の問題が解消しないため、API実行の母数を必要最小限に減らします。
現状利用していないリソース情報の収集は一旦削減します（すべてのプロジェクトでスキャン成功させる方を優先したいため）