### PR TITLE
fix score

### DIFF
--- a/src/cloudsploit/Dockerfile
+++ b/src/cloudsploit/Dockerfile
@@ -20,7 +20,9 @@ FROM node:lts-alpine3.12
 RUN apk add --no-cache ca-certificates tzdata git \
   && mkdir -p /var/scan/ && cd /var/scan/ \
   && git clone https://github.com/aquasecurity/cloudsploit.git -b v2.0.0 --depth 1 \
-  && npm init --yes && npm install cloudsploit
+  && npm init --yes && npm install cloudsploit \
+  # Check `cloudsploitscan` file
+  && ls /var/scan/node_modules/.bin/cloudsploitscan
 COPY --from=builder /go/bin/env-injector /usr/local/bin/
 COPY --from=builder /go/bin/cloudsploit /usr/local/cloudsploit/bin/
 ENV PATH="$PATH:/var/scan/node_modules/.bin" \
@@ -39,7 +41,7 @@ ENV PATH="$PATH:/var/scan/node_modules/.bin" \
   FINDING_SVC_ADDR= \
   ALERT_SVC_ADDR= \
   GOOGLE_SVC_ADDR= \
-  CLOUD_SPLOIT_COMMAND="cloudsploit-scan" \
+  CLOUD_SPLOIT_COMMAND="cloudsploitscan" \
   GOOGLE_SERVICE_ACCOUNT_EMAIL= \
   GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY= \
   TZ=Asia/Tokyo

--- a/src/cloudsploit/cloudsploit.go
+++ b/src/cloudsploit/cloudsploit.go
@@ -28,7 +28,7 @@ type cloudSploitClient struct {
 }
 
 type cloudSploitConf struct {
-	CloudSploitCommand             string `required:"true" split_words:"true" default:"cloudsploit-scan"`
+	CloudSploitCommand             string `required:"true" split_words:"true" default:"cloudsploitscan"`
 	GoogleServiceAccountEmail      string `required:"true" split_words:"true"`
 	GoogleServiceAccountPrivateKey string `required:"true" split_words:"true"`
 }
@@ -239,9 +239,12 @@ func (c *cloudSploitFinding) setTags() {
 // scoreMap (key: `{Categor}/{Plugin}`, value: score)
 var scoreMap = map[string]float32{
 	categorySQL + "/dbPubliclyAccessible":               0.8, // CloudSQL
+	categorySQL + "/dbAutomatedBackups":                 0.6, // CloudSQL
 	categoryCompute + "/instanceLeastPrivilege":         0.6, // GCE
+	categoryCompute + "/connectSerialPortsDisabled":     0.6, // GCE
 	categoryStorage + "/bucketAllUsersPolicy":           0.6, // GCS
 	categoryKubernetes + "/loggingEnabled":              0.6, // GKE
+	categoryKubernetes + "/clusterLeastPrivilege":       0.6, // GKE
 	categoryIAM + "/corporateEmailsOnly":                0.8, // IAM
 	categoryIAM + "/serviceAccountAdmin":                0.6, // IAM
 	categoryIAM + "/serviceAccountUser":                 0.6, // IAM


### PR DESCRIPTION
CloudSploitのスコア修正します。

```
google:cloudsploitの以下３つのプラグインのスコアを 0.3 から 0.6 に変更お願いします。
connectSerialPortsDisabled
clusterLeastPrivilege
dbAutomatedBackups
```