### PR TITLE
Use common base images

### DIFF
--- a/src/asset/Dockerfile
+++ b/src/asset/Dockerfile
@@ -1,8 +1,7 @@
 FROM golang:1.16 as builder
 WORKDIR /go/src/github.com/ca-risken/google/src/asset/
 ADD *.go go.* ./
-ENV CGO_ENABLED=0 GOPRIVATE="github.com/CyberAgent/*,github.com/ca-risken/*"
-ARG ENV_INJECTOR_VERSION=v0.0.6
+ENV CGO_ENABLED=0 GOPRIVATE="github.com/ca-risken/*"
 ARG GITHUB_USER
 ARG GITHUB_TOKEN
 RUN echo "machine github.com" > ~/.netrc
@@ -10,15 +9,7 @@ RUN echo "login $GITHUB_USER" >> ~/.netrc
 RUN echo "password $GITHUB_TOKEN" >> ~/.netrc
 RUN go build && cp asset /go/bin/
 
-WORKDIR /go/src/github.com/gassara-kys
-RUN git clone https://github.com/gassara-kys/env-injector.git -b ${ENV_INJECTOR_VERSION} \
-  && cd env-injector \
-  && go build \
-  && cp env-injector /go/bin/
-
-FROM alpine
-RUN apk add --no-cache ca-certificates tzdata
-COPY --from=builder /go/bin/env-injector /usr/local/bin/
+FROM public.ecr.aws/risken/base/risken-base:v0.0.1
 COPY --from=builder /go/bin/asset /usr/local/asset/bin/
 ADD docker-entrypoint.sh /usr/local/bin
 ENV DEBUG= \

--- a/src/cloudsploit/Dockerfile
+++ b/src/cloudsploit/Dockerfile
@@ -1,8 +1,7 @@
 FROM golang:1.16 as builder
 WORKDIR /go/src/github.com/ca-risken/google/src/cloudsploit/
 ADD *.go go.* ./
-ENV CGO_ENABLED=0 GOPRIVATE="github.com/CyberAgent/*,github.com/ca-risken/*"
-ARG ENV_INJECTOR_VERSION=v0.0.6
+ENV CGO_ENABLED=0 GOPRIVATE="github.com/ca-risken/*"
 ARG GITHUB_USER
 ARG GITHUB_TOKEN
 RUN echo "machine github.com" > ~/.netrc
@@ -10,19 +9,7 @@ RUN echo "login $GITHUB_USER" >> ~/.netrc
 RUN echo "password $GITHUB_TOKEN" >> ~/.netrc
 RUN go build && cp cloudsploit /go/bin/
 
-WORKDIR /go/src/github.com/gassara-kys
-RUN git clone https://github.com/gassara-kys/env-injector.git -b ${ENV_INJECTOR_VERSION} \
-  && cd env-injector \
-  && go build \
-  && cp env-injector /go/bin/
-
-FROM node:lts-alpine3.12
-RUN apk add --no-cache ca-certificates tzdata git \
-  && cd /opt  \
-  && git clone https://github.com/aquasecurity/cloudsploit.git -b v2.0.0 --depth 1 && cd cloudsploit \
-  && yarn install  \
-  && chmod +x index.js
-COPY --from=builder /go/bin/env-injector /usr/local/bin/
+FROM public.ecr.aws/risken/base/cloudsploit-base:v0.0.1
 COPY --from=builder /go/bin/cloudsploit /usr/local/cloudsploit/bin/
 ENV DEBUG= \
   AWS_REGION= \

--- a/src/google/Dockerfile
+++ b/src/google/Dockerfile
@@ -1,8 +1,7 @@
 FROM golang:1.16 as builder
 WORKDIR /go/src/github.com/ca-risken/google/src/google/
 ADD *.go go.* ./
-ENV CGO_ENABLED=0 GOPRIVATE="github.com/CyberAgent/*,github.com/ca-risken/*"
-ARG ENV_INJECTOR_VERSION=v0.0.6
+ENV CGO_ENABLED=0 GOPRIVATE="github.com/ca-risken/*"
 ARG GITHUB_USER
 ARG GITHUB_TOKEN
 RUN echo "machine github.com" > ~/.netrc
@@ -10,15 +9,7 @@ RUN echo "login $GITHUB_USER" >> ~/.netrc
 RUN echo "password $GITHUB_TOKEN" >> ~/.netrc
 RUN go build && cp google /go/bin/
 
-WORKDIR /go/src/github.com/gassara-kys
-RUN git clone https://github.com/gassara-kys/env-injector.git -b ${ENV_INJECTOR_VERSION} \
-    && cd env-injector \
-    && go build \
-    && cp env-injector /go/bin/
-
-FROM alpine
-RUN apk add --no-cache ca-certificates tzdata
-COPY --from=builder /go/bin/env-injector /usr/local/bin/
+FROM public.ecr.aws/risken/base/risken-base:v0.0.1
 COPY --from=builder /go/bin/google /usr/local/google/bin/
 ADD docker-entrypoint.sh /usr/local/bin
 ENV PORT= \

--- a/src/portscan/Dockerfile
+++ b/src/portscan/Dockerfile
@@ -1,8 +1,7 @@
 FROM golang:1.16 as builder
 WORKDIR /go/src/github.com/ca-risken/google/src/portscan/
 ADD *.go go.* ./
-ENV CGO_ENABLED=0 GOPRIVATE="github.com/CyberAgent/*,github.com/ca-risken/*"
-ARG ENV_INJECTOR_VERSION=v0.0.6
+ENV CGO_ENABLED=0 GOPRIVATE="github.com/ca-risken/*"
 ARG GITHUB_USER
 ARG GITHUB_TOKEN
 RUN echo "machine github.com" > ~/.netrc
@@ -10,15 +9,8 @@ RUN echo "login $GITHUB_USER" >> ~/.netrc
 RUN echo "password $GITHUB_TOKEN" >> ~/.netrc
 RUN go build && cp portscan /go/bin/
 
-WORKDIR /go/src/github.com/gassara-kys
-RUN git clone https://github.com/gassara-kys/env-injector.git -b ${ENV_INJECTOR_VERSION} \
-    && cd env-injector \
-    && go build \
-    && cp env-injector /go/bin/
-
-FROM alpine
-RUN apk add --no-cache ca-certificates tzdata nmap nmap-scripts
-COPY --from=builder /go/bin/env-injector /usr/local/bin/
+FROM public.ecr.aws/risken/base/risken-base:v0.0.1
+RUN apk add --no-cache nmap nmap-scripts
 COPY --from=builder /go/bin/portscan /usr/local/portscan/bin/
 ADD docker-entrypoint.sh /usr/local/bin
 ENV DEBUG= \

--- a/src/scc/Dockerfile
+++ b/src/scc/Dockerfile
@@ -1,8 +1,7 @@
 FROM golang:1.16 as builder
 WORKDIR /go/src/github.com/ca-risken/google/src/scc/
 ADD *.go go.* ./
-ENV CGO_ENABLED=0 GOPRIVATE="github.com/CyberAgent/*,github.com/ca-risken/*"
-ARG ENV_INJECTOR_VERSION=v0.0.6
+ENV CGO_ENABLED=0 GOPRIVATE="github.com/ca-risken/*"
 ARG GITHUB_USER
 ARG GITHUB_TOKEN
 RUN echo "machine github.com" > ~/.netrc
@@ -10,15 +9,7 @@ RUN echo "login $GITHUB_USER" >> ~/.netrc
 RUN echo "password $GITHUB_TOKEN" >> ~/.netrc
 RUN go build && cp scc /go/bin/
 
-WORKDIR /go/src/github.com/gassara-kys
-RUN git clone https://github.com/gassara-kys/env-injector.git -b ${ENV_INJECTOR_VERSION} \
-    && cd env-injector \
-    && go build \
-    && cp env-injector /go/bin/
-
-FROM alpine
-RUN apk add --no-cache ca-certificates tzdata
-COPY --from=builder /go/bin/env-injector /usr/local/bin/
+FROM public.ecr.aws/risken/base/risken-base:v0.0.1
 COPY --from=builder /go/bin/scc /usr/local/scc/bin/
 ADD docker-entrypoint.sh /usr/local/bin
 ENV DEBUG= \


### PR DESCRIPTION
CloudSploit用のbaseイメージを作る必要がある
他のnamespaceでも必要になるので、commonに入れる予定
そのイメージを使うように変更したらマージします
ビルドが遅いようなら、nmapのインストール済みのイメージを作る