### PR TITLE
fix: get service name

### DIFF
--- a/pkg/common/resource_name.go
+++ b/pkg/common/resource_name.go
@@ -7,11 +7,12 @@ const UnknownService string = "unknown"
 
 // GetShortResourceName return short resoruce name from `fullResourceName`. (Resource name format: https://cloud.google.com/asset-inventory/docs/resource-name-format)
 func GetShortResourceName(gcpProjectID, fullResourceName string) string {
+	service := GetServiceName(fullResourceName)
 	array := strings.Split(fullResourceName, "/")
 	if len(array) < 2 {
-		return getResourceName(gcpProjectID, UnknownService, fullResourceName)
+		return getResourceName(gcpProjectID, service, fullResourceName)
 	}
-	return getResourceName(gcpProjectID, array[len(array)-2], array[len(array)-1])
+	return getResourceName(gcpProjectID, service, array[len(array)-1])
 }
 
 // getResourceName return `{gcpProjectID}/{serviceName}/{resourceName}`
@@ -21,9 +22,13 @@ func getResourceName(gcpProjectID, serviceName, resourceName string) string {
 
 // GetServiceName return service name from `fullResourceName`. (Resource name format: https://cloud.google.com/asset-inventory/docs/resource-name-format)
 func GetServiceName(fullResourceName string) string {
-	array := strings.Split(fullResourceName, "/")
-	if len(array) < 2 {
+	array := strings.Split(strings.Replace(fullResourceName, "//", "", 1), "/")
+	if len(array) < 1 {
 		return UnknownService
 	}
-	return array[len(array)-2]
+	svc := array[0]
+	if !strings.Contains(svc, ".googleapis.com") {
+		return UnknownService
+	}
+	return strings.ReplaceAll(svc, ".googleapis.com", "")
 }

--- a/pkg/common/resource_name_test.go
+++ b/pkg/common/resource_name_test.go
@@ -20,7 +20,7 @@ func TestGetShortResourceName(t *testing.T) {
 		{
 			name:  "OK",
 			input: "//iam.googleapis.com/projects/my-project/service/some-asset",
-			want:  "my-project/service/some-asset",
+			want:  "my-project/iam/some-asset",
 		},
 		{
 			name:  "Unknown service",
@@ -47,7 +47,12 @@ func TestGetServiceName(t *testing.T) {
 		{
 			name:  "OK",
 			input: "//iam.googleapis.com/projects/my-project/service/some-asset",
-			want:  "service",
+			want:  "iam",
+		},
+		{
+			name:  "OK",
+			input: "//storage.googleapis.com/some-bucket",
+			want:  "storage",
 		},
 		{
 			name:  "Unknown service",


### PR DESCRIPTION
Service名取得の↓のフォーマットにあわせて修正
https://cloud.google.com/asset-inventory/docs/resource-name-format