### PR TITLE
fix: public ci flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ TARGETS = asset cloudsploit google portscan scc
 BUILD_TARGETS = $(TARGETS:=.build)
 BUILD_CI_TARGETS = $(TARGETS:=.build-ci)
 IMAGE_PUSH_TARGETS = $(TARGETS:=.push-image)
+IMAGE_PULL_TARGETS = $(TARGETS:=.pull-image)
+IMAGE_TAG_TARGETS = $(TARGETS:=.tag-image)
 MANIFEST_CREATE_TARGETS = $(TARGETS:=.create-manifest)
 MANIFEST_PUSH_TARGETS = $(TARGETS:=.push-manifest)
 TEST_TARGETS = $(TARGETS:=.go-test)
@@ -62,6 +64,16 @@ build-ci: $(BUILD_CI_TARGETS)
 push-image: $(IMAGE_PUSH_TARGETS)
 %.push-image: FAKE
 	docker push $(IMAGE_REGISTRY)/$(IMAGE_PREFIX)/$(*):$(IMAGE_TAG)
+
+PHONY: pull-image $(IMAGE_PULL_TARGETS)
+pull-image: $(IMAGE_PULL_TARGETS)
+%.pull-image:
+	docker pull $(IMAGE_REGISTRY)/$(IMAGE_PREFIX)/$(*):$(IMAGE_TAG)
+
+PHONY: tag-image $(IMAGE_TAG_TARGETS)
+tag-image: $(IMAGE_TAG_TARGETS)
+%.tag-image:
+	docker tag $(SOURCE_IMAGE_PREFIX)/$(*):$(SOURCE_IMAGE_TAG) $(IMAGE_REGISTRY)/$(IMAGE_PREFIX)/$(*):$(IMAGE_TAG)
 
 .PHONY: create-manifest
 create-manifest: $(MANIFEST_CREATE_TARGETS)

--- a/codebuild/multi-arch/buildspec-manifest.yml
+++ b/codebuild/multi-arch/buildspec-manifest.yml
@@ -2,10 +2,10 @@ version: 0.2
 
 env:
   variables:
-    IMAGE_PREFIX: "risken-google"
+    IMAGE_PREFIX: 'risken-google'
   parameter-store:
-    GITHUB_USER: "/build/GITHUB_USER"
-    GITHUB_TOKEN: "/build/GITHUB_TOKEN"
+    GITHUB_USER: '/build/GITHUB_USER'
+    GITHUB_TOKEN: '/build/GITHUB_TOKEN'
 
 phases:
   install:
@@ -29,6 +29,7 @@ phases:
     commands:
       - echo Create manifests...
       - make create-manifest -j IMAGE_REGISTRY=${REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG_BASE=${IMAGE_TAG_BASE} MANIFEST_TAG=${MANIFEST_TAG}
+      - make create-manifest -j IMAGE_REGISTRY=${REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG_BASE=${IMAGE_TAG_BASE} MANIFEST_TAG=${CODEBUILD_RESOLVED_SOURCE_VERSION}
       - make create-manifest -j IMAGE_REGISTRY=${REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG_BASE=${IMAGE_TAG_BASE} MANIFEST_TAG=latest
 
   post_build:
@@ -36,5 +37,5 @@ phases:
       - echo Build completed on `date`
       - echo Pushing the Docker manifest...
       - make push-manifest -j IMAGE_REGISTRY=${REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} MANIFEST_TAG=${MANIFEST_TAG}
+      - make push-manifest -j IMAGE_REGISTRY=${REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} MANIFEST_TAG=${CODEBUILD_RESOLVED_SOURCE_VERSION}
       - make push-manifest -j IMAGE_REGISTRY=${REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} MANIFEST_TAG=latest
-

--- a/codebuild/release/buildspec-image.yml
+++ b/codebuild/release/buildspec-image.yml
@@ -2,18 +2,15 @@ version: 0.2
 
 env:
   variables:
-    REGISTRY: "public.ecr.aws/risken"
-    IMAGE_PREFIX: "google"
+    PRIVATE_IMAGE_PREFIX: 'risken-google'
+    PUBLIC_REGISTRY: 'public.ecr.aws/risken'
+    PUBLIC_IMAGE_PREFIX: 'google'
   parameter-store:
-    GITHUB_USER: "/build/GITHUB_USER"
-    GITHUB_TOKEN: "/build/GITHUB_TOKEN"
-    DOCKER_USER: "/build/DOCKER_USER"
-    DOCKER_TOKEN: "/build/DOCKER_TOKEN"
+    GITHUB_USER: '/build/GITHUB_USER'
+    GITHUB_TOKEN: '/build/GITHUB_TOKEN'
 
 phases:
   install:
-    runtime-versions:
-      golang: 1.14
     commands:
       - echo "machine github.com" > ~/.netrc
       - echo "login ${GITHUB_USER}" >> ~/.netrc
@@ -21,30 +18,30 @@ phases:
   pre_build:
     commands:
       - echo Setting environment variables
-      - BUILD_OPT="--no-cache --pull"
+      - AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+      - PRIVATE_REGISTRY=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
       - TAG=${CODEBUILD_WEBHOOK_TRIGGER#tag/}
       - IMAGE_TAG=${TAG}_${OS}_${ARCH}
-      - AWS_XRAY_SDK_DISABLED=TRUE
 
-      - echo Logging in to Amazon ECR...
+      - echo Logging in to private Amazon ECR...
       - aws --version
-      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin  ${REGISTRY}
-
-      - |
-        #!/bin/bash
-        if [[ -n "${DOCKER_USER}" ]] && [[ -n "${DOCKER_TOKEN}" ]]; then
-          echo 'Logging in to Docker Hub...'
-          echo "$DOCKER_TOKEN" | docker login -u $DOCKER_USER --password-stdin
-        fi
-      - make go-test -j
+      - aws ecr get-login-password --region ${AWS_DEFAULT_REGION} | docker login --username AWS --password-stdin ${PRIVATE_REGISTRY}
   build:
     commands:
-      - echo Build gateway started on `date`
-      - echo Pushing the Docker images...
-      - make build-ci -j BUILD_OPT="${BUILD_OPT}" IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG=${IMAGE_TAG} IMAGE_REGISTRY=${REGISTRY}
+      - echo Build started on `date`
+      - echo pull images...
+      - make pull-image -j IMAGE_PREFIX=${PRIVATE_IMAGE_PREFIX} IMAGE_REGISTRY=${PRIVATE_REGISTRY} IMAGE_TAG=${CODEBUILD_RESOLVED_SOURCE_VERSION}
+
+      - echo tag images...
+      - SOURCE_IMAGE_PREFIX=${PRIVATE_REGISTRY}/${PRIVATE_IMAGE_PREFIX}
+      - make tag-image -j SOURCE_IMAGE_PREFIX=${SOURCE_IMAGE_PREFIX} SOURCE_IMAGE_TAG=${CODEBUILD_RESOLVED_SOURCE_VERSION} IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_TAG=${IMAGE_TAG}
 
   post_build:
     commands:
+      - echo Logging in to public Amazon ECR ...
+      - aws --version
+      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${PUBLIC_REGISTRY}
+
       - echo Build completed on `date`
       - echo Pushing the Docker image...
-      - make push-image -j IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG=${IMAGE_TAG} IMAGE_REGISTRY=${REGISTRY}
+      - make push-image -j IMAGE_PREFIX=${PUBLIC_IMAGE_PREFIX} IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_TAG=${IMAGE_TAG}

--- a/codebuild/release/buildspec-manifest.yml
+++ b/codebuild/release/buildspec-manifest.yml
@@ -2,12 +2,12 @@ version: 0.2
 
 env:
   variables:
-    REGISTRY: "public.ecr.aws/risken"
-    IMAGE_PREFIX: "google"
+    PUBLIC_REGISTRY: 'public.ecr.aws/risken'
+    IMAGE_PREFIX: 'google'
 
   parameter-store:
-    GITHUB_USER: "/build/GITHUB_USER"
-    GITHUB_TOKEN: "/build/GITHUB_TOKEN"
+    GITHUB_USER: '/build/GITHUB_USER'
+    GITHUB_TOKEN: '/build/GITHUB_TOKEN'
 
 phases:
   install:
@@ -23,16 +23,18 @@ phases:
 
       - echo Logging in to Amazon ECR...
       - aws --version
-      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${REGISTRY}
+      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${PUBLIC_REGISTRY}
   build:
     commands:
       - echo Create manifests...
-      - make create-manifest -j IMAGE_REGISTRY=${REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG_BASE=${TAG} MANIFEST_TAG=${TAG}
-      - make create-manifest -j IMAGE_REGISTRY=${REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG_BASE=${TAG} MANIFEST_TAG=latest
+      - make create-manifest -j IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG_BASE=${TAG} MANIFEST_TAG=${CODEBUILD_RESOLVED_SOURCE_VERSION}
+      - make create-manifest -j IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG_BASE=${TAG} MANIFEST_TAG=${TAG}
+      - make create-manifest -j IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG_BASE=${TAG} MANIFEST_TAG=latest
 
   post_build:
     commands:
       - echo Build completed on `date`
       - echo Pushing the Docker manifest...
-      - make push-manifest -j IMAGE_REGISTRY=${REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} MANIFEST_TAG=${TAG}
-      - make push-manifest -j IMAGE_REGISTRY=${REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} MANIFEST_TAG=latest
+      - make push-manifest -j IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} MANIFEST_TAG=${CODEBUILD_RESOLVED_SOURCE_VERSION}
+      - make push-manifest -j IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} MANIFEST_TAG=${TAG}
+      - make push-manifest -j IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} MANIFEST_TAG=latest


### PR DESCRIPTION
common同様、公開イメージのビルドフローを修正します。
https://github.com/ca-risken/common/tree/master/codebuild/release 

- 非公開レジストリへのイメージpush時にGitハッシュ値をイメージタグに付与しておく
- タグ打ちのタイミングでGitハッシュ値のタグ（↑）からビルド済みのイメージをpull
- 公開レジストリにイメージpush