### PR TITLE
fix: delete gcp

### DIFF
--- a/src/google/service.go
+++ b/src/google/service.go
@@ -118,8 +118,16 @@ func (g *googleService) DeleteGCP(ctx context.Context, req *google.DeleteGCPRequ
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	err := g.repository.DeleteGCP(ctx, req.ProjectId, req.GcpId)
-	if err != nil {
+	list, err := g.repository.ListGoogleDataSource(ctx, 0, "")
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+	for _, ds := range *list {
+		if err := g.repository.DeleteGCPDataSource(ctx, req.ProjectId, req.GcpId, ds.GoogleDataSourceID); err != nil {
+			return nil, err
+		}
+	}
+	if err := g.repository.DeleteGCP(ctx, req.ProjectId, req.GcpId); err != nil {
 		return nil, err
 	}
 	return &google.Empty{}, nil

--- a/src/google/service.go
+++ b/src/google/service.go
@@ -118,8 +118,8 @@ func (g *googleService) DeleteGCP(ctx context.Context, req *google.DeleteGCPRequ
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	list, err := g.repository.ListGoogleDataSource(ctx, 0, "")
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+	list, err := g.repository.ListGCPDataSource(ctx, req.ProjectId, req.GcpId)
+	if err != nil {
 		return nil, err
 	}
 	for _, ds := range *list {

--- a/src/google/service_test.go
+++ b/src/google/service_test.go
@@ -282,7 +282,7 @@ func TestDeleteGCP(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			mockDB.On("ListGoogleDataSource").Return(&[]common.GoogleDataSource{{GoogleDataSourceID: 1}}, nil)
+			mockDB.On("ListGCPDataSource").Return(&[]gcpDataSource{{GoogleDataSourceID: 1}}, nil)
 			mockDB.On("DeleteGCPDataSource").Return(nil)
 			mockDB.On("DeleteGCP").Return(c.mockError).Once()
 			_, err := svc.DeleteGCP(ctx, c.input)

--- a/src/google/service_test.go
+++ b/src/google/service_test.go
@@ -282,6 +282,8 @@ func TestDeleteGCP(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			mockDB.On("ListGoogleDataSource").Return(&[]common.GoogleDataSource{{GoogleDataSourceID: 1}}, nil)
+			mockDB.On("DeleteGCPDataSource").Return(nil)
 			mockDB.On("DeleteGCP").Return(c.mockError).Once()
 			_, err := svc.DeleteGCP(ctx, c.input)
 			if !c.wantErr && err != nil {


### PR DESCRIPTION
DeleteGCPで関連データを削除する処理を追加（データ不整合が起きてしまうため）

ref https://github.com/ca-risken/internal-community/issues/269