### PR TITLE
Fix blank tag error in portscan

### DIFF
--- a/src/portscan/finding.go
+++ b/src/portscan/finding.go
@@ -21,6 +21,10 @@ func (s *sqsHandler) putNmapFindings(ctx context.Context, projectID uint32, gcpP
 	}
 	findings := nmapResult.GetFindings(projectID, common.PortscanDataSource, string(data))
 	tags := nmapResult.GetTags()
+	if len(tags) == 0 {
+		// nmapResult.GetTags returns the slice that has empty element in some condition.
+		appLogger.Infof(ctx, "nmapResult has empty or unknown service, nmapResult: %v", nmapResult)
+	}
 	tags = append(tags, gcpProjectID)
 	err = s.putFindings(ctx, findings, tags, categoryNmap)
 	if err != nil {

--- a/src/portscan/go.mod
+++ b/src/portscan/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.16.4
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.18.5
 	github.com/ca-risken/common/pkg/logging v0.0.0-20220520051921-497abce3e602
-	github.com/ca-risken/common/pkg/portscan v0.0.0-20220525094706-413e91572a52
+	github.com/ca-risken/common/pkg/portscan v0.0.0-20220530101213-876a1f5fa110
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20220304031727-c94e2c463b27
 	github.com/ca-risken/common/pkg/sqs v0.0.0-20220525094706-413e91572a52
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20220425094653-eace2e0a3d4a

--- a/src/portscan/go.sum
+++ b/src/portscan/go.sum
@@ -158,10 +158,8 @@ github.com/ca-risken/common/pkg/logging v0.0.0-20220426050416-a654045b9fa5/go.mo
 github.com/ca-risken/common/pkg/logging v0.0.0-20220518032134-ad443b601efd/go.mod h1:iqLbvDuf708TWjF8RO5qw6Nx1e3R0/UEHZ8tE/VEPjA=
 github.com/ca-risken/common/pkg/logging v0.0.0-20220520051921-497abce3e602 h1:cmDdv6i6xd9jbeH2Qf9ydQi0rhS2DDoLnlN4nXp8n6Q=
 github.com/ca-risken/common/pkg/logging v0.0.0-20220520051921-497abce3e602/go.mod h1:iqLbvDuf708TWjF8RO5qw6Nx1e3R0/UEHZ8tE/VEPjA=
-github.com/ca-risken/common/pkg/portscan v0.0.0-20211118071101-9855266b50a1 h1:Z7xy+bCkdb4HKXRdtb9YDkkUJ3ZJTNdOAL0E9pKPR3k=
-github.com/ca-risken/common/pkg/portscan v0.0.0-20211118071101-9855266b50a1/go.mod h1:4JgzkE62Dv8uTvhAqTRE8KQWIZ6oQX2CcgfS6nf/I4Q=
-github.com/ca-risken/common/pkg/portscan v0.0.0-20220525094706-413e91572a52 h1:AkQ0/kOqBG7iXm1hW9MJZ3A5eFsAuCxiCGI2LXWfhWI=
-github.com/ca-risken/common/pkg/portscan v0.0.0-20220525094706-413e91572a52/go.mod h1:Fa8YzcvEpZJWQNYLI+toBvuD8o4wwEnvk5oOH6nLCrA=
+github.com/ca-risken/common/pkg/portscan v0.0.0-20220530101213-876a1f5fa110 h1:dC1rlZS3JkxsxNvcdvTuxlWHZMVriTSaI8HPg1plog0=
+github.com/ca-risken/common/pkg/portscan v0.0.0-20220530101213-876a1f5fa110/go.mod h1:Fa8YzcvEpZJWQNYLI+toBvuD8o4wwEnvk5oOH6nLCrA=
 github.com/ca-risken/common/pkg/profiler v0.0.0-20220304031727-c94e2c463b27 h1:NV95obXJwovUBvxWPW5boJcMAwkUIrsqhH3uwhTfTNY=
 github.com/ca-risken/common/pkg/profiler v0.0.0-20220304031727-c94e2c463b27/go.mod h1:xldq3VZ7qomkI5vfpw8Y9qCVEFl8BrSvDr+sxbz32H4=
 github.com/ca-risken/common/pkg/sqs v0.0.0-20220525094706-413e91572a52 h1:WCi2Ofmr7uFXwn85TDZNd6ydktjtntCiPyMHDjeaE7I=


### PR DESCRIPTION
`nmapResult.Service`が空文字の場合、`nmapResult.GetTags()`が空文字を要素に持つスライスを返した結果`s.putFindings()`がエラーを返していた事象を解決。
上記の事象がどういう条件で発生するか不明なため、当該データをログに出力するようにしています。