### PR TITLE
Fix portscan

### DIFF
--- a/src/portscan/enumerater_test.go
+++ b/src/portscan/enumerater_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+)
+
+func TestHandleGoogleAPIError(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   error
+		wantErr bool
+	}{
+		{
+			name: "No error",
+			input: &googleapi.Error{
+				Header: http.Header{},
+				Code:   403,
+				Details: []interface{}{
+					map[string]interface{}{
+						"@type":  "type.googleapis.com/google.rpc.ErrorInfo",
+						"reason": "SERVICE_DISABLED",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Error 1",
+			input:   errors.New("something error"),
+			wantErr: true,
+		},
+		{
+			name: "Error 2",
+			input: &googleapi.Error{
+				Details: []interface{}{
+					1,
+					true,
+					"test",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error 3",
+			input: &googleapi.Error{
+				Details: []interface{}{
+					map[string]interface{}{"unknown": true},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error 4",
+			input: &googleapi.Error{
+				Details: []interface{}{
+					map[string]interface{}{"@type": 1},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error 5",
+			input: &googleapi.Error{
+				Details: []interface{}{
+					map[string]interface{}{
+						"@type":  "unknown",
+						"reason": 1,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error 6",
+			input: &googleapi.Error{
+				Details: []interface{}{
+					map[string]interface{}{
+						"@type":  "unknown",
+						"reason": "unknown",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error 7",
+			input: &googleapi.Error{
+				Details: []interface{}{
+					map[string]interface{}{
+						"@type":  "type.googleapis.com/google.rpc.ErrorInfo",
+						"reason": "unknown",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error 7",
+			input: &googleapi.Error{
+				Details: []interface{}{
+					map[string]interface{}{
+						"@type":  "unknown",
+						"reason": "SERVICE_DISABLED",
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := handleGoogleAPIError(context.TODO(), c.input)
+			if c.wantErr && err == nil {
+				t.Errorf("Unexpected no error")
+			}
+			if !c.wantErr && err != nil {
+				t.Errorf("Unexpected error ocurred, err=%+v", err)
+			}
+		})
+	}
+}

--- a/src/portscan/go.sum
+++ b/src/portscan/go.sum
@@ -161,8 +161,6 @@ github.com/ca-risken/common/pkg/logging v0.0.0-20220517105456-de734080357a/go.mo
 github.com/ca-risken/common/pkg/logging v0.0.0-20220518032134-ad443b601efd/go.mod h1:iqLbvDuf708TWjF8RO5qw6Nx1e3R0/UEHZ8tE/VEPjA=
 github.com/ca-risken/common/pkg/logging v0.0.0-20220601065422-5b97bd6efc9b h1:qNttEBJBsXg68Kzj0+9rw7c52L9rhgaChZOyUO/A4VQ=
 github.com/ca-risken/common/pkg/logging v0.0.0-20220601065422-5b97bd6efc9b/go.mod h1:iqLbvDuf708TWjF8RO5qw6Nx1e3R0/UEHZ8tE/VEPjA=
-github.com/ca-risken/common/pkg/portscan v0.0.0-20220530101213-876a1f5fa110 h1:dC1rlZS3JkxsxNvcdvTuxlWHZMVriTSaI8HPg1plog0=
-github.com/ca-risken/common/pkg/portscan v0.0.0-20220530101213-876a1f5fa110/go.mod h1:Fa8YzcvEpZJWQNYLI+toBvuD8o4wwEnvk5oOH6nLCrA=
 github.com/ca-risken/common/pkg/portscan v0.0.0-20220704030129-763bad09525b h1:CbMJES3iT8TOHLZ3ru3sJO7IClsKZX/mbxKb673OMiU=
 github.com/ca-risken/common/pkg/portscan v0.0.0-20220704030129-763bad09525b/go.mod h1:Fa8YzcvEpZJWQNYLI+toBvuD8o4wwEnvk5oOH6nLCrA=
 github.com/ca-risken/common/pkg/profiler v0.0.0-20220601065422-5b97bd6efc9b h1:S3vrpeI7invfVyBw0PhZ15/A/kIV9AOPTXpc+e7RQdU=

--- a/src/portscan/handler.go
+++ b/src/portscan/handler.go
@@ -91,6 +91,10 @@ func (s *sqsHandler) scan(ctx context.Context, gcpProjectId string, msg *message
 	if err != nil {
 		return err
 	}
+	if targets == nil && relFirewallResourceMap == nil {
+		appLogger.Infof(ctx, "No scan taget, project=%s", gcpProjectId)
+		return nil // skip scan
+	}
 	targets, excludeList := s.portscanClient.excludeTarget(targets)
 	eg, errGroupCtx := errgroup.WithContext(ctx)
 	mutex := &sync.Mutex{}


### PR DESCRIPTION
portscanでスキャン対象のfirewallルールを取得する処理で、computeのAPIが `SERVICE_DISABLED` だった場合に限り、（Computeサービスを使っておらずAPIが有効化されていないケース）エラー扱いにしないよう修正します。
