### PR TITLE
Improve error handling in asset

### DIFF
--- a/src/asset/asset.go
+++ b/src/asset/asset.go
@@ -29,34 +29,34 @@ type assetClient struct {
 	gcs     *storage.Client
 }
 
-func newAssetClient(credentialPath string) assetServiceClient {
+func newAssetClient(credentialPath string) (assetServiceClient, error) {
 	ctx := context.Background()
 	pj, err := cloudresourcemanager.NewService(ctx, option.WithCredentialsFile(credentialPath))
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to authenticate for CloudResourceManager API client: %+v", err)
+		return nil, fmt.Errorf("failed to authenticate for CloudResourceManager API client: %w", err)
 	}
 	as, err := asset.NewClient(ctx, option.WithCredentialsFile(credentialPath))
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to authenticate for Google Asset API client: %+v", err)
+		return nil, fmt.Errorf("failed to authenticate for Google Asset API client: %w", err)
 	}
 	ad, err := admin.NewIamClient(ctx, option.WithCredentialsFile(credentialPath))
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to authenticate for Google IAM Admin API client: %+v", err)
+		return nil, fmt.Errorf("failed to authenticate for Google IAM Admin API client: %w", err)
 	}
 	st, err := storage.NewClient(ctx, option.WithCredentialsFile(credentialPath))
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to authenticate for Google Cloud Storage client: %+v", err)
+		return nil, fmt.Errorf("failed to authenticate for Google Cloud Storage client: %w", err)
 	}
 	// Remove credential file for Security
 	if err := os.Remove(credentialPath); err != nil {
-		appLogger.Fatalf(ctx, "Failed to remove file: path=%s, err=%+v", credentialPath, err)
+		return nil, fmt.Errorf("failed to remove file: path=%s, err=%w", credentialPath, err)
 	}
 	return &assetClient{
 		project: pj,
 		asset:   as,
 		admin:   ad,
 		gcs:     st,
-	}
+	}, nil
 }
 
 const (

--- a/src/asset/grpc_client.go
+++ b/src/asset/grpc_client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ca-risken/core/proto/alert"
@@ -11,31 +12,31 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func newFindingClient(svcAddr string) finding.FindingServiceClient {
+func newFindingClient(svcAddr string) (finding.FindingServiceClient, error) {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "failed to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return finding.NewFindingServiceClient(conn)
+	return finding.NewFindingServiceClient(conn), nil
 }
 
-func newAlertClient(svcAddr string) alert.AlertServiceClient {
+func newAlertClient(svcAddr string) (alert.AlertServiceClient, error) {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "failed to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return alert.NewAlertServiceClient(conn)
+	return alert.NewAlertServiceClient(conn), nil
 }
 
-func newGoogleClient(svcAddr string) google.GoogleServiceClient {
+func newGoogleClient(svcAddr string) (google.GoogleServiceClient, error) {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "failed to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return google.NewGoogleServiceClient(conn)
+	return google.NewGoogleServiceClient(conn), nil
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {

--- a/src/asset/main.go
+++ b/src/asset/main.go
@@ -100,7 +100,10 @@ func main() {
 	if err != nil {
 		appLogger.Fatalf(ctx, "Failed to create google client, err=%+v", err)
 	}
-	assetClient := newAssetClient(conf.GoogleCredentialPath)
+	assetClient, err := newAssetClient(conf.GoogleCredentialPath)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create asset client, err=%+v", err)
+	}
 	handler := &sqsHandler{
 		waitMilliSecPerRequest: conf.WaitMilliSecPerRequest,
 		assetAPIRetryNum:       conf.AssetAPIRetryNum,

--- a/src/asset/main.go
+++ b/src/asset/main.go
@@ -111,7 +111,10 @@ func main() {
 		MaxNumberOfMessage: conf.MaxNumberOfMessage,
 		WaitTimeSecond:     conf.WaitTimeSecond,
 	}
-	consumer := newSQSConsumer(ctx, sqsConf)
+	consumer, err := newSQSConsumer(ctx, sqsConf)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create SQS consumer, err=%+v", err)
+	}
 	appLogger.Info(ctx, "start the SQS consumer server for GCP Cloud Asset Inventory...")
 	consumer.Start(ctx,
 		mimosasqs.InitializeHandler(

--- a/src/asset/sqs.go
+++ b/src/asset/sqs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/go-sqs-poller/worker/v5"
@@ -19,14 +20,14 @@ type SQSConfig struct {
 	WaitTimeSecond     int32
 }
 
-func newSQSConsumer(ctx context.Context, conf *SQSConfig) *worker.Worker {
+func newSQSConsumer(ctx context.Context, conf *SQSConfig) (*worker.Worker, error) {
 	if conf.Debug == "true" {
 		appLogger.Level(logging.DebugLevel)
 	}
 
 	client, err := worker.CreateSqsClient(ctx, conf.AWSRegion, conf.SQSEndpoint)
 	if err != nil {
-		appLogger.Fatalf(ctx, "failed to create a new client, %v", err)
+		return nil, fmt.Errorf("failed to create a new SQS client, %w", err)
 	}
 
 	appLogger.Infof(ctx, "created SQS client, sqsConfig=%+v", conf)
@@ -39,5 +40,5 @@ func newSQSConsumer(ctx context.Context, conf *SQSConfig) *worker.Worker {
 		},
 		Log:       appLogger,
 		SqsClient: client,
-	}
+	}, nil
 }


### PR DESCRIPTION
src/asset配下のエラーハンドリング改善しました。

* client生成時のエラーは呼び出し元でハンドリングするために呼び出し元に返すようにしています。
* handleErrorWithUpdateStatusはステータスの更新とエラーのラッピングという二つの責務を持っていたので、見通しをよくするために分割しました。責務に合わせてメソッド名も変更しています。