### PR TITLE
Improve error handling in portscan

### DIFF
--- a/src/portscan/enumerater.go
+++ b/src/portscan/enumerater.go
@@ -25,21 +25,21 @@ type portscanClient struct {
 	ScanExcludePortNumber int
 }
 
-func newPortscanClient(credentialPath string, scanExcludePortNumber int) portscanServiceClient {
+func newPortscanClient(credentialPath string, scanExcludePortNumber int) (portscanServiceClient, error) {
 	ctx := context.Background()
 	compute, err := compute.NewService(ctx, option.WithCredentialsFile(credentialPath))
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to authenticate for Compute service: %+v", err)
+		return nil, fmt.Errorf("failed to authenticate for Compute service: %w", err)
 	}
 
 	// Remove credential file for Security
 	if err := os.Remove(credentialPath); err != nil {
-		appLogger.Fatalf(ctx, "Failed to remove file: path=%s, err=%+v", credentialPath, err)
+		return nil, fmt.Errorf("failed to remove file: path=%s, err=%w", credentialPath, err)
 	}
 	return &portscanClient{
 		compute:               compute,
 		ScanExcludePortNumber: scanExcludePortNumber,
-	}
+	}, nil
 }
 
 func (p *portscanClient) listTarget(ctx context.Context, gcpProjectID string) ([]*target, map[string]*relFirewallResource, error) {

--- a/src/portscan/grpc_client.go
+++ b/src/portscan/grpc_client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ca-risken/core/proto/alert"
@@ -11,31 +12,31 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func newFindingClient(svcAddr string) finding.FindingServiceClient {
+func newFindingClient(svcAddr string) (finding.FindingServiceClient, error) {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return finding.NewFindingServiceClient(conn)
+	return finding.NewFindingServiceClient(conn), nil
 }
 
-func newAlertClient(svcAddr string) alert.AlertServiceClient {
+func newAlertClient(svcAddr string) (alert.AlertServiceClient, error) {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return alert.NewAlertServiceClient(conn)
+	return alert.NewAlertServiceClient(conn), nil
 }
 
-func newGoogleClient(svcAddr string) google.GoogleServiceClient {
+func newGoogleClient(svcAddr string) (google.GoogleServiceClient, error) {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return google.NewGoogleServiceClient(conn)
+	return google.NewGoogleServiceClient(conn), nil
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {

--- a/src/portscan/handler.go
+++ b/src/portscan/handler.go
@@ -141,18 +141,21 @@ func (s *sqsHandler) scan(ctx context.Context, gcpProjectId string, msg *message
 	for _, result := range nmapResults {
 		err := s.putNmapFindings(ctx, msg.ProjectID, gcpProjectId, result)
 		if err != nil {
-			appLogger.Errorf(ctx, "Failed put Finding err: %v", err)
+			appLogger.Errorf(ctx, "Failed to put Finding err: %v", err)
+			return err
 		}
 	}
 	if relFirewallResourceMap != nil {
 		err := s.putRelFirewallResourceFindings(ctx, gcpProjectId, relFirewallResourceMap, msg)
 		if err != nil {
-			appLogger.Errorf(ctx, "Failed put firewall resource Finding err: %v", err)
+			appLogger.Errorf(ctx, "Failed to put firewall resource Finding err: %v", err)
+			return err
 		}
 	}
 	err = s.putExcludeFindings(ctx, gcpProjectId, excludeList, msg)
 	if err != nil {
 		appLogger.Errorf(ctx, "Failed put exclude Finding err: %v", err)
+		return err
 	}
 	return nil
 }

--- a/src/portscan/main.go
+++ b/src/portscan/main.go
@@ -97,7 +97,10 @@ func main() {
 	if err != nil {
 		appLogger.Fatalf(ctx, "Failed to create google client, err=%+v", err)
 	}
-	portscanClient := newPortscanClient(conf.GoogleCredentialPath, conf.ScanExcludePortNumber)
+	portscanClient, err := newPortscanClient(conf.GoogleCredentialPath, conf.ScanExcludePortNumber)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create portscan client, err=%+v", err)
+	}
 	handler := &sqsHandler{
 		findingClient:   findingClient,
 		alertClient:     alertClient,

--- a/src/portscan/main.go
+++ b/src/portscan/main.go
@@ -119,7 +119,10 @@ func main() {
 		MaxNumberOfMessage: conf.MaxNumberOfMessage,
 		WaitTimeSecond:     conf.WaitTimeSecond,
 	}
-	consumer := newSQSConsumer(ctx, sqsConf)
+	consumer, err := newSQSConsumer(ctx, sqsConf)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create SQS consumer, err=%+v", err)
+	}
 	appLogger.Info(ctx, "Start the SQS consumer server for GCP Portscan Service")
 	consumer.Start(ctx,
 		mimosasqs.InitializeHandler(

--- a/src/portscan/main.go
+++ b/src/portscan/main.go
@@ -85,12 +85,26 @@ func main() {
 	defer tracer.Stop()
 
 	appLogger.Info(ctx, "Start")
-	handler := &sqsHandler{}
-	handler.findingClient = newFindingClient(conf.CoreSvcAddr)
-	handler.alertClient = newAlertClient(conf.CoreSvcAddr)
-	handler.googleClient = newGoogleClient(conf.DataSourceAPISvcAddr)
-	handler.portscanClient = newPortscanClient(conf.GoogleCredentialPath, conf.ScanExcludePortNumber)
-	handler.scanConcurrency = conf.ScanConcurrency
+	findingClient, err := newFindingClient(conf.CoreSvcAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create finding client, err=%+v", err)
+	}
+	alertClient, err := newAlertClient(conf.CoreSvcAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create alert client, err=%+v", err)
+	}
+	googleClient, err := newGoogleClient(conf.DataSourceAPISvcAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create google client, err=%+v", err)
+	}
+	portscanClient := newPortscanClient(conf.GoogleCredentialPath, conf.ScanExcludePortNumber)
+	handler := &sqsHandler{
+		findingClient:   findingClient,
+		alertClient:     alertClient,
+		googleClient:    googleClient,
+		portscanClient:  portscanClient,
+		scanConcurrency: conf.ScanConcurrency,
+	}
 	f, err := mimosasqs.NewFinalizer(message.GooglePortscanDataSource, settingURL, conf.CoreSvcAddr, nil)
 	if err != nil {
 		appLogger.Fatalf(ctx, "Failed to create Finalizer, err=%+v", err)

--- a/src/portscan/sqs.go
+++ b/src/portscan/sqs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/go-sqs-poller/worker/v5"
@@ -19,14 +20,14 @@ type SQSConfig struct {
 	WaitTimeSecond     int32
 }
 
-func newSQSConsumer(ctx context.Context, conf *SQSConfig) *worker.Worker {
+func newSQSConsumer(ctx context.Context, conf *SQSConfig) (*worker.Worker, error) {
 	if conf.Debug == "true" {
 		appLogger.Level(logging.DebugLevel)
 	}
 
 	client, err := worker.CreateSqsClient(ctx, conf.AWSRegion, conf.SQSEndpoint)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to create a new client, %v", err)
+		return nil, fmt.Errorf("failed to create a new sqs client, %w", err)
 	}
 
 	return &worker.Worker{
@@ -38,5 +39,5 @@ func newSQSConsumer(ctx context.Context, conf *SQSConfig) *worker.Worker {
 		},
 		Log:       appLogger,
 		SqsClient: client,
-	}
+	}, nil
 }


### PR DESCRIPTION
src/portscan配下のエラーハンドリング改善しました。

* client生成時のエラーは呼び出し元でハンドリングするために呼び出し元に返すようにしています。
* handleErrorWithUpdateStatusはステータスの更新とエラーのラッピングという二つの責務を持っていたので、見通しをよくするために分割しました。責務に合わせてメソッド名も変更しています。
* findings登録でエラーが発生した場合、呼び出し元にエラーを返すようにしています。