### PR TITLE
Improve error handling in scc

### DIFF
--- a/src/scc/grpc_client.go
+++ b/src/scc/grpc_client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ca-risken/core/proto/alert"
@@ -11,31 +12,28 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func newFindingClient(svcAddr string) finding.FindingServiceClient {
-	ctx := context.Background()
+func newFindingClient(ctx context.Context, svcAddr string) (finding.FindingServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return finding.NewFindingServiceClient(conn)
+	return finding.NewFindingServiceClient(conn), nil
 }
 
-func newAlertClient(svcAddr string) alert.AlertServiceClient {
-	ctx := context.Background()
+func newAlertClient(ctx context.Context, svcAddr string) (alert.AlertServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return alert.NewAlertServiceClient(conn)
+	return alert.NewAlertServiceClient(conn), nil
 }
 
-func newGoogleClient(svcAddr string) google.GoogleServiceClient {
-	ctx := context.Background()
+func newGoogleClient(ctx context.Context, svcAddr string) (google.GoogleServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return google.NewGoogleServiceClient(conn)
+	return google.NewGoogleServiceClient(conn), nil
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {

--- a/src/scc/main.go
+++ b/src/scc/main.go
@@ -116,7 +116,10 @@ func main() {
 		MaxNumberOfMessage: conf.MaxNumberOfMessage,
 		WaitTimeSecond:     conf.WaitTimeSecond,
 	}
-	consumer := newSQSConsumer(ctx, sqsConf)
+	consumer, err := newSQSConsumer(ctx, sqsConf)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create SQS consumer, err=%+v", err)
+	}
 
 	appLogger.Info(ctx, "start the SQS consumer server for GCP Security Command Center...")
 	consumer.Start(ctx,

--- a/src/scc/main.go
+++ b/src/scc/main.go
@@ -83,24 +83,27 @@ func main() {
 	defer tracer.Stop()
 
 	appLogger.Info(ctx, "start")
-	findingClient, err := newFindingClient(ctx, conf.CoreSvcAddr)
+	fc, err := newFindingClient(ctx, conf.CoreSvcAddr)
 	if err != nil {
 		appLogger.Fatalf(ctx, "Failed to create finding client, err=%+v", err)
 	}
-	alertClient, err := newAlertClient(ctx, conf.CoreSvcAddr)
+	ac, err := newAlertClient(ctx, conf.CoreSvcAddr)
 	if err != nil {
 		appLogger.Fatalf(ctx, "Failed to create alert client, err=%+v", err)
 	}
-	googleClient, err := newGoogleClient(ctx, conf.DataSourceAPISvcAddr)
+	gc, err := newGoogleClient(ctx, conf.DataSourceAPISvcAddr)
 	if err != nil {
 		appLogger.Fatalf(ctx, "Failed to create google client, err=%+v", err)
 	}
-	sccClient := newSCCClient(conf.GoogleCredentialPath)
+	sc, err := newSCCClient(ctx, conf.GoogleCredentialPath)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create scc client, err=%+v", err)
+	}
 	handler := &sqsHandler{
-		findingClient: findingClient,
-		alertClient:   alertClient,
-		googleClient:  googleClient,
-		sccClient:     sccClient,
+		findingClient: fc,
+		alertClient:   ac,
+		googleClient:  gc,
+		sccClient:     sc,
 	}
 	f, err := mimosasqs.NewFinalizer(message.GoogleSCCDataSource, settingURL, conf.CoreSvcAddr, nil)
 	if err != nil {

--- a/src/scc/scc.go
+++ b/src/scc/scc.go
@@ -18,17 +18,16 @@ type sccClient struct {
 	client *scc.Client
 }
 
-func newSCCClient(credentialPath string) sccServiceClient {
-	ctx := context.Background()
+func newSCCClient(ctx context.Context, credentialPath string) (sccServiceClient, error) {
 	c, err := scc.NewClient(ctx, option.WithCredentialsFile(credentialPath))
 	if err != nil {
-		appLogger.Fatalf(ctx, "failed to authenticate for Google API client: %+v", err)
+		return nil, fmt.Errorf("failed to authenticate for Google API client: %w", err)
 	}
 	// Remove credential file for Security
 	if err := os.Remove(credentialPath); err != nil {
-		appLogger.Fatalf(ctx, "failed to remove file: path=%s, err=%+v", credentialPath, err)
+		return nil, fmt.Errorf("failed to remove file: path=%s, err=%w", credentialPath, err)
 	}
-	return &sccClient{client: c}
+	return &sccClient{client: c}, nil
 }
 
 func (g *sccClient) listFinding(ctx context.Context, gcpOrganizationID, gcpProjectID string) *scc.ListFindingsResponse_ListFindingsResultIterator {

--- a/src/scc/sqs.go
+++ b/src/scc/sqs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/go-sqs-poller/worker/v5"
@@ -19,14 +20,14 @@ type SQSConfig struct {
 	WaitTimeSecond     int32
 }
 
-func newSQSConsumer(ctx context.Context, conf *SQSConfig) *worker.Worker {
+func newSQSConsumer(ctx context.Context, conf *SQSConfig) (*worker.Worker, error) {
 	if conf.Debug == "true" {
 		appLogger.Level(logging.DebugLevel)
 	}
 
 	client, err := worker.CreateSqsClient(ctx, conf.AWSRegion, conf.SQSEndpoint)
 	if err != nil {
-		appLogger.Fatalf(ctx, "failed to create a new client, %v", err)
+		return nil, fmt.Errorf("failed to create a new SQS client, %w", err)
 	}
 
 	return &worker.Worker{
@@ -38,5 +39,5 @@ func newSQSConsumer(ctx context.Context, conf *SQSConfig) *worker.Worker {
 		},
 		Log:       appLogger,
 		SqsClient: client,
-	}
+	}, nil
 }


### PR DESCRIPTION
src/scc配下のエラーハンドリング改善しました。

* client生成時のエラーは呼び出し元でハンドリングするために呼び出し元に返すようにしています。
* handleErrorWithUpdateStatusはステータスの更新とエラーのラッピングという二つの責務を持っていたので、見通しをよくするために分割しました。責務に合わせてメソッド名も変更しています。