### PR TITLE
revert: cloudsploit version

### DIFF
--- a/dockers/cloudsploit/Dockerfile
+++ b/dockers/cloudsploit/Dockerfile
@@ -6,25 +6,8 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o /go/bin/cloudsploit cmd/cloudsploit/main.go
 
-FROM node:lts-alpine3.12 as cloudsploit
-# 2022/12/14時点で最新
-ARG CLOUDSPLOIT_COMMIT_HASH=9f467ff72d75faf76bfe8fee52cca503b2b78191
-RUN apk add --no-cache ca-certificates tzdata git \
-  && mkdir -p /opt/cloudsploit \
-  && cd /opt/cloudsploit \
-  && git init \
-  && git remote add origin https://github.com/aquasecurity/cloudsploit.git \
-  && git fetch origin ${CLOUDSPLOIT_COMMIT_HASH} --depth 1 \
-  && git checkout FETCH_HEAD \
-  && yarn install  \
-  && chmod +x index.js
-
-FROM public.ecr.aws/risken/base/risken-base:v0.0.1 as risken-base
-
-FROM node:lts-alpine3.12
+FROM public.ecr.aws/risken/base/cloudsploit-base:v0.0.1
 COPY --from=builder /go/bin/cloudsploit /usr/local/cloudsploit/bin/
-COPY --from=cloudsploit /opt/cloudsploit /opt/cloudsploit
-COPY --from=risken-base /usr/local/bin/env-injector /usr/local/bin/
 ENV DEBUG= \
   PROFILE_EXPORTER= \
   PROFILE_TYPES= \


### PR DESCRIPTION
旧バージョンでスキャンを実行した後にバージョンが最新になってしまうバグがありました。
旧バージョンではspecific_versionに対応しておらず、スキャン後にspecific_versionのデータがクリアされてしまうことが原因となります。

一度、specific_versionに対応した状態で、CloudSploitを前のバージョンに戻してイメージを作成します。（specific_versionに対応済みのもの）

このPRの後に、CloudSploitのバージョンを最新化する更新を入れる予定です。