### PR TITLE
add: exponential backoff

### DIFF
--- a/cmd/asset/main.go
+++ b/cmd/asset/main.go
@@ -50,11 +50,6 @@ type AppConfig struct {
 	GoogleAssetQueueURL  string `split_words:"true" default:"http://queue.middleware.svc.cluster.local:9324/queue/google-asset"`
 	MaxNumberOfMessage   int32  `split_words:"true" default:"10"`
 	WaitTimeSecond       int32  `split_words:"true" default:"20"`
-
-	// handler
-	WaitMilliSecPerRequest int `split_words:"true" default:"500"`
-	AssetAPIRetryNum       int `split_words:"true" default:"3"`
-	AssetAPIRetryWaitSec   int `split_words:"true" default:"30"`
 }
 
 func main() {
@@ -115,9 +110,6 @@ func main() {
 		ac,
 		gc,
 		assetc,
-		conf.WaitMilliSecPerRequest,
-		conf.AssetAPIRetryNum,
-		conf.AssetAPIRetryWaitSec,
 		appLogger,
 	)
 	f, err := mimosasqs.NewFinalizer(message.GoogleAssetDataSource, settingURL, conf.CoreSvcAddr, nil)

--- a/cmd/scc/main.go
+++ b/cmd/scc/main.go
@@ -101,7 +101,7 @@ func main() {
 	if err != nil {
 		appLogger.Fatalf(ctx, "Failed to create google client, err=%+v", err)
 	}
-	sc, err := scc.NewSCCClient(ctx, conf.GoogleCredentialPath)
+	sc, err := scc.NewSCCClient(ctx, conf.GoogleCredentialPath, appLogger)
 	if err != nil {
 		appLogger.Fatalf(ctx, "Failed to create scc client, err=%+v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/ca-risken/core v0.5.1-0.20230131022604-6ee078ff449c
 	github.com/ca-risken/datasource-api v0.4.2-0.20221215091113-c6e727315ba7
 	github.com/ca-risken/go-sqs-poller/worker/v5 v5.0.0-20220525093235-9148d33b6aee
+	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/gassara-kys/envconfig v1.4.4
 	github.com/vikyd/zero v0.0.0-20190921142904-0f738d0bc858
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/ca-risken/datasource-api v0.4.2-0.20221215091113-c6e727315ba7 h1:gjds
 github.com/ca-risken/datasource-api v0.4.2-0.20221215091113-c6e727315ba7/go.mod h1:cCsoQDX58kDJWpsmszG1HbjmwWyQtvIvDCrKUuDdu5Y=
 github.com/ca-risken/go-sqs-poller/worker/v5 v5.0.0-20220525093235-9148d33b6aee h1:aIrvjCnF+Owzzh7dnE1w4442CdcuUkHaJsJOXImjeqg=
 github.com/ca-risken/go-sqs-poller/worker/v5 v5.0.0-20220525093235-9148d33b6aee/go.mod h1:pboVfH7X3jKqsVKSpYNYAgqgPQ6gVb+AjFuWH1e8dSU=
+github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=
+github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=


### PR DESCRIPTION
GCPのAPIで大量にコールが発生する部分にExponentialBackoffを導入します。
- asset
- security command center

asset APIはもともとリトライの仕組みが入ってましたが、独自実装からExponentialBackoffに切り替えます