### PR TITLE
increase: fetch size

### DIFF
--- a/pkg/scc/scc.go
+++ b/pkg/scc/scc.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	maxIterationFetch = 500
+	maxIterationFetch = 1000
 )
 
 type SCCServiceClient interface {


### PR DESCRIPTION
フェッチサイズを増やすことでパフォーマンスがかなり改善したのとCPUメモリ（主にメモリ）消費もそれほどインパクトがなかったので、もう少し増やしてみたいと思います。

また、Datadog用のトレースはSpanが細かいためGCPプロジェクトによってはかなり生成されてしまうのでコストにも影響します。
そこまで細かい単位でのトレースは不要と判断したのでspanの位置を調整します。