### PR TITLE
fix target protocol

### DIFF
--- a/pkg/portscan/enumerater.go
+++ b/pkg/portscan/enumerater.go
@@ -238,7 +238,7 @@ func (p *PortscanClient) listTargetForwardingRule(ctx context.Context, com *comp
 				Name:         fmt.Sprintf("%v/%v/%v", gcpProjectID, "ForwardingRule", fr.Name),
 				ResourceName: p.getFullResourceName(ctx, fr.SelfLink),
 				IpVersion:    fr.IpVersion,
-				IPProtocol:   fr.IPProtocol,
+				IPProtocol:   strings.ToLower(fr.IPProtocol),
 			})
 		}
 	}


### PR DESCRIPTION
スキャン対象のIP Protocolを判別する際に、ca-risken/commonのportscanでは、小文字での判定をしていましたが
gcpのFirewall RuleではProtocolが大文字で出力されるので、修正します