### PR TITLE
add: SCC asset info

### DIFF
--- a/pkg/scc/handler.go
+++ b/pkg/scc/handler.go
@@ -146,7 +146,6 @@ func (s *SqsHandler) putFindings(
 
 		findingBatchParam := []*finding.FindingBatchForUpsert{}
 		for _, f := range result.findings {
-			// TODO: ここでassetを取得する
 			data, err := s.generateFindingData(ctx, gcp.ProjectId, gcp.GcpProjectId, f)
 			if err != nil {
 				return nil, fmt.Errorf("generate finding error: err=%w", err)


### PR DESCRIPTION
SAキーやインスタンスIDなど人間に優しくない表示では、オペレーション時に調査が必要で大変なのでFindingにアセット情報を追加します。

フィールド名をresourceではなくassetにしたのは、RISKENの表示上なるべく上側に表示されるようにしたかったためです