### PR TITLE
support: SCC API v2

### DIFF
--- a/pkg/scc/finding_test.go
+++ b/pkg/scc/finding_test.go
@@ -3,7 +3,7 @@ package scc
 import (
 	"testing"
 
-	sccpb "cloud.google.com/go/securitycenter/apiv1/securitycenterpb"
+	sccpb "cloud.google.com/go/securitycenter/apiv2/securitycenterpb"
 )
 
 func TestExtractShortResourceName(t *testing.T) {
@@ -153,6 +153,48 @@ func TestGenerateSccURL(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			got := generateSccURL(c.input.name, c.input.gcpProjectID)
+			if c.want != got {
+				t.Fatalf("Unexpected: want=%+v, got=%+v", c.want, got)
+			}
+		})
+	}
+}
+
+func TestFormatSccDataSourceID(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "APIv2 format with locations/global",
+			input: "organizations/111/sources/222/locations/global/findings/333",
+			want:  "organizations/111/sources/222/findings/333",
+		},
+		{
+			name:  "APIv2 format with locations/us-central1",
+			input: "organizations/111/sources/222/locations/us-central1/findings/333",
+			want:  "organizations/111/sources/222/findings/333",
+		},
+		{
+			name:  "APIv1 format (already in correct format)",
+			input: "organizations/111/sources/222/findings/333",
+			want:  "organizations/111/sources/222/findings/333",
+		},
+		{
+			name:  "Invalid format",
+			input: "invalid-format",
+			want:  "invalid-format",
+		},
+		{
+			name:  "Empty string",
+			input: "",
+			want:  "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := formatSccDataSourceID(c.input)
 			if c.want != got {
 				t.Fatalf("Unexpected: want=%+v, got=%+v", c.want, got)
 			}

--- a/pkg/scc/scc_test.go
+++ b/pkg/scc/scc_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	sccpb "cloud.google.com/go/securitycenter/apiv1/securitycenterpb"
+	sccpb "cloud.google.com/go/securitycenter/apiv2/securitycenterpb"
 	"github.com/ca-risken/common/pkg/logging"
 )
 


### PR DESCRIPTION
SCC API v2のサポートです（API v1で取得していたデータも引き続き取得可能です）

https://cloud.google.com/security-command-center/docs/migrate-v2-api?hl=ja

> 2024 年 12 月 9 日以降、組織内で Security Command Center を初めて有効にする場合は、その組織で Security Command Center API のバージョン 2 のみを使用する必要があります。以前のバージョンはサポートされていません。