### PR TITLE
fix: bugs(tag length & bucket public)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/ca-risken/common/pkg/portscan v0.0.0-20230501023912-29382763676f
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20221119073224-9db027bda6f8
 	github.com/ca-risken/common/pkg/sqs v0.0.0-20221119073224-9db027bda6f8
+	github.com/ca-risken/common/pkg/strings v0.0.0-20250616082029-e3cd176cfcdb
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d
 	github.com/ca-risken/core v0.11.1-0.20250204074349-42f821288247
 	github.com/ca-risken/datasource-api v0.4.2-0.20221215091113-c6e727315ba7
@@ -22,7 +23,7 @@ require (
 	github.com/ca-risken/vulnerability v0.0.0-20241119125125-0693660e1024
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/gassara-kys/envconfig v1.4.4
-	github.com/google/go-cmp v0.6.0
+	github.com/google/go-cmp v0.7.0
 	github.com/vikyd/zero v0.0.0-20190921142904-0f738d0bc858
 	golang.org/x/sync v0.10.0
 	google.golang.org/api v0.214.0

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/ca-risken/common/pkg/profiler v0.0.0-20221119073224-9db027bda6f8 h1:7
 github.com/ca-risken/common/pkg/profiler v0.0.0-20221119073224-9db027bda6f8/go.mod h1:/U/wZ+4lsT9oDDRT2Kp4XDcfVt6qaF9PmzRpbpxERko=
 github.com/ca-risken/common/pkg/sqs v0.0.0-20221119073224-9db027bda6f8 h1:qkGWlFgaOYeqPhvfn+5FMGfoj2ut02TDpYblwatvB1I=
 github.com/ca-risken/common/pkg/sqs v0.0.0-20221119073224-9db027bda6f8/go.mod h1:OuXf9lf0tOf/9vd2LJ9peTv6YCYTsJTd9/1LAVxUeZY=
+github.com/ca-risken/common/pkg/strings v0.0.0-20250616082029-e3cd176cfcdb h1:WipOquXFgSk/j2/MKvQv9j+Mvln8yxJK9msMwce4nLQ=
+github.com/ca-risken/common/pkg/strings v0.0.0-20250616082029-e3cd176cfcdb/go.mod h1:Eo1gQLHEOi9uMEJG2kE/CazdfnsDNVhdizxRpKDeFy0=
 github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d h1:d+QWOmwmL2YjVWmTlbabmhdCSTnDuiJWxSf8siQbSrM=
 github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d/go.mod h1:c6ENRTqNN5hOCB85fZHvEjMhDWt87dpN20Wz6j91InU=
 github.com/ca-risken/core v0.11.1-0.20250204074349-42f821288247 h1:OWvGeqmZUkevxg75pFoCfncQGOvulW4pwXYeSNfp3ck=
@@ -196,8 +198,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/pkg/asset/handler.go
+++ b/pkg/asset/handler.go
@@ -481,10 +481,10 @@ func getAssetDescription(a *assetFinding, score float32) string {
 
 	// Specific description
 	if description != "" {
-		return riskenstr.TruncateString(description, 200, "...")
+		return riskenstr.TruncateString(description, 150, "...")
 	}
 
 	// Default description
 	description = fmt.Sprintf("Detected GCP asset (type=%s, name=%s)", assetType, a.Asset.DisplayName)
-	return riskenstr.TruncateString(description, 200, "...")
+	return riskenstr.TruncateString(description, 150, "...")
 }

--- a/pkg/asset/handler.go
+++ b/pkg/asset/handler.go
@@ -462,23 +462,29 @@ func writableRole(role string) bool {
 
 func getAssetDescription(a *assetFinding, score float32) string {
 	assetType := ""
+	description := ""
+
+	// AssetType
 	if a.Asset.AssetType == assetTypeServiceAccount {
 		assetType = "ServiceAccount"
 		if score >= 0.8 {
-			return fmt.Sprintf("Detected a privileged service-account that has owner(or editor) role. (name=%s)", a.Asset.DisplayName)
+			description = fmt.Sprintf("Detected a privileged service-account that has owner(or editor) role. (name=%s)", a.Asset.DisplayName)
 		}
-	}
-	dispName := riskenstr.TruncateString(a.Asset.DisplayName, 200, "...")
-	if a.Asset.AssetType == assetTypeBucket {
+	} else if a.Asset.AssetType == assetTypeBucket {
 		assetType = "Bucket"
 		if score >= 0.7 {
-			return fmt.Sprintf("Detected public bucket. (name=%s)", dispName)
+			description = fmt.Sprintf("Detected public bucket. (name=%s)", a.Asset.DisplayName)
 		}
+	} else {
+		assetType = a.Asset.AssetType
 	}
 
-	description := fmt.Sprintf("Detected GCP asset (name=%s)", dispName)
-	if assetType != "" {
-		description = fmt.Sprintf("Detected GCP asset (type=%s, name=%s)", assetType, dispName)
+	// Specific description
+	if description != "" {
+		return riskenstr.TruncateString(description, 200, "...")
 	}
-	return description
+
+	// Default description
+	description = fmt.Sprintf("Detected GCP asset (type=%s, name=%s)", assetType, a.Asset.DisplayName)
+	return riskenstr.TruncateString(description, 200, "...")
 }

--- a/pkg/asset/handler_test.go
+++ b/pkg/asset/handler_test.go
@@ -368,7 +368,7 @@ func TestGetAssetDescription(t *testing.T) {
 				},
 				score: 0.8,
 			},
-			want: "Detected GCP asset (name=any-name)",
+			want: "Detected GCP asset (type=any-type, name=any-name)",
 		},
 	}
 	for _, c := range cases {

--- a/pkg/asset/handler_test.go
+++ b/pkg/asset/handler_test.go
@@ -119,7 +119,7 @@ func TestScoreAsset(t *testing.T) {
 				},
 				BucketPublicAccessPrevention: Ptr(storage.PublicAccessPreventionInherited),
 			},
-			want: 0.1,
+			want: 0.7,
 		},
 	}
 	for _, c := range cases {

--- a/pkg/scc/finding.go
+++ b/pkg/scc/finding.go
@@ -10,6 +10,7 @@ import (
 	sccv2 "cloud.google.com/go/securitycenter/apiv2"
 	sccv2pb "cloud.google.com/go/securitycenter/apiv2/securitycenterpb"
 	"github.com/ca-risken/common/pkg/grpc_client"
+	riskenstr "github.com/ca-risken/common/pkg/strings"
 	triage "github.com/ca-risken/core/pkg/server/finding"
 	"github.com/ca-risken/core/proto/finding"
 	"github.com/ca-risken/datasource-api/pkg/message"
@@ -127,8 +128,8 @@ func (s *SqsHandler) generateFindingData(ctx context.Context, projectID uint32, 
 			{Tag: common.TagGoogle},
 			{Tag: common.TagGCP},
 			{Tag: common.TagSCC},
-			{Tag: gcpProjectID},
-			{Tag: common.GetServiceName(f.ResourceName)},
+			{Tag: riskenstr.TruncateString(gcpProjectID, 64, "")},
+			{Tag: riskenstr.TruncateString(common.GetServiceName(f.ResourceName), 64, "")},
 		},
 	}
 	if cve != "" {
@@ -136,7 +137,9 @@ func (s *SqsHandler) generateFindingData(ctx context.Context, projectID uint32, 
 		findingData.Tag = append(findingData.Tag, &finding.FindingTagForBatch{Tag: cve})
 	}
 	if resourceShortName != "" {
-		findingData.Tag = append(findingData.Tag, &finding.FindingTagForBatch{Tag: resourceShortName})
+		findingData.Tag = append(findingData.Tag, &finding.FindingTagForBatch{
+			Tag: riskenstr.TruncateString(resourceShortName, 64, ""),
+		})
 	}
 
 	riskDescription := f.Category


### PR DESCRIPTION
以下の2点のバグ修正です

- タグの文字数64を超過するケースがあってスキャンがエラーになるのでTruncateします
- バケットのバリック判定を修正
  - 「組織から継承する」という設定になっていてもパブリックブロックになっているとは限らない
  - 実際は組織の設定をみないと判断できないが、一旦除外したい
  - デフォルト継承なのでパブリック判定ができなくなっている