### PR TITLE
add: GitHub Actions workflow for building and tagging container on PRs for Google

### DIFF
--- a/.github/workflows/build-pr-google.yml
+++ b/.github/workflows/build-pr-google.yml
@@ -1,0 +1,21 @@
+name: Build and Tag Container for PR Google
+
+on: 
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+jobs:
+  build-pr-google:
+    uses: ca-risken/.github/.github/workflows/build-pr.yml@main
+    with:
+      runs_on: codebuild-mimosa-google-pr-runner-${{ github.run_id }}-${{ github.run_attempt }}
+      install_go_version: "1.22.12"
+      golangci_lint_version: "v1.55.2"
+      image_prefix: "risken-google"
+      test_command: "go-test"
+      aws_xray_sdk_disabled: "true"
+    secrets:
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+      DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}

--- a/.github/workflows/build-pr-google.yml
+++ b/.github/workflows/build-pr-google.yml
@@ -13,8 +13,6 @@ jobs:
       install_go_version: "1.22.12"
       golangci_lint_version: "v1.55.2"
       image_prefix: "risken-google"
-      test_command: "go-test"
-      aws_xray_sdk_disabled: "true"
     secrets:
       DOCKER_USER: ${{ secrets.DOCKER_USER }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
googleに関連付けられていたcodebuildを置き換えるためにgithub actionsのワークフローを追加します。
awsやcoreのものとgolangのバージョンを除き、同じ内容です。